### PR TITLE
Fix energy shape, use muCorrected energy

### DIFF
--- a/Train/june_format_example_nf_pca_double_coords.py
+++ b/Train/june_format_example_nf_pca_double_coords.py
@@ -36,7 +36,7 @@ from Layers import LocalClusterReshapeFromNeighbours2,ManualCoordTransform,Ragge
 from Layers import GooeyBatchNorm #make a new line
 from datastructures import TrainData_OC
 
-td=TrainData_OC()
+td=TrainData_NanoML()
 '''
 
 '''
@@ -52,7 +52,7 @@ def gravnet_model(Inputs,
     feature_dropout=-1.
     addBackGatherInfo=True,
 
-    feat,  t_idx, t_energy, t_pos, t_time, t_pid, row_splits = td.interpretAllModelInputs(Inputs)
+    feat,  t_idx, t_energy, t_pos, t_time, t_pid, t_spectator, t_fully_contained, row_splits = td.interpretAllModelInputs(Inputs)
     orig_t_idx, orig_t_energy, orig_t_pos, orig_t_time, orig_t_pid, orig_row_splits = t_idx, t_energy, t_pos, t_time, t_pid, row_splits
     gidx_orig = CreateGlobalIndices()(feat)
 

--- a/modules/datastructures/TrainData_NanoML.py
+++ b/modules/datastructures/TrainData_NanoML.py
@@ -183,7 +183,7 @@ class TrainData_NanoML(TrainData):
         recHitTruthDepEnergy = self.truthObjects(simClusterDepEnergy, recHitSimClusIdx, 0)
         recHitTruthEnergy = self.truthObjects(simClusterEnergy, recHitSimClusIdx, 0)
         low_energy_shower_cutoff = 3
-        recHitTruthEnergy = np.expand_dims(np.where(recHitTruthEnergy>low_energy_shower_cutoff, recHitTruthEnergy,recHitTruthDepEnergy),axis=1)
+        recHitTruthEnergy = np.where(recHitTruthEnergy>low_energy_shower_cutoff, recHitTruthEnergy,recHitTruthDepEnergy)
 
         #very bad names because these quatities are associated to Merged Clusters and not hits
         recHitTruthEnergyCorrMu = self.truthObjects(simClusterEnergyMuCorr, recHitSimClusIdx, 0)
@@ -270,7 +270,7 @@ class TrainData_NanoML(TrainData):
         t_idxarr = SimpleArray(recHitSimClusIdx, offsets, name="recHitTruthClusterIdx")
         
         t_energyarr = SimpleArray(name="recHitTruthEnergy")
-        t_energyarr.createFromNumpy(recHitTruthEnergy, offsets)
+        t_energyarr.createFromNumpy(recHitTruthEnergyCorrMu, offsets)
         
         t_posarr = SimpleArray(name="recHitTruthPosition")
         t_posarr.createFromNumpy(np.concatenate([recHitTruthX, recHitTruthY],axis=-1), offsets)

--- a/modules/datastructures/TrainData_NanoML.py
+++ b/modules/datastructures/TrainData_NanoML.py
@@ -182,11 +182,14 @@ class TrainData_NanoML(TrainData):
         recHitTruthPID = self.truthObjects(simClusterPdgId, recHitSimClusIdx, 0.)
         recHitTruthDepEnergy = self.truthObjects(simClusterDepEnergy, recHitSimClusIdx, 0)
         recHitTruthEnergy = self.truthObjects(simClusterEnergy, recHitSimClusIdx, 0)
+        recHitTruthEnergyCorrMu = self.truthObjects(simClusterEnergyMuCorr, recHitSimClusIdx, 0)
+
         low_energy_shower_cutoff = 3
+        # Uncorrected currently not used 
         recHitTruthEnergy = np.where(recHitTruthEnergy>low_energy_shower_cutoff, recHitTruthEnergy,recHitTruthDepEnergy)
+        recHitTruthEnergy = np.where(recHitTruthEnergyCorrMu>low_energy_shower_cutoff, recHitTruthEnergyCorrMu,recHitTruthDepEnergy)
 
         #very bad names because these quatities are associated to Merged Clusters and not hits
-        recHitTruthEnergyCorrMu = self.truthObjects(simClusterEnergyMuCorr, recHitSimClusIdx, 0)
         recHitTruthX = self.truthObjects(simClusterX, recHitSimClusIdx, 0)
         recHitTruthY = self.truthObjects(simClusterY, recHitSimClusIdx, 0)
         recHitTruthZ = self.truthObjects(simClusterZ, recHitSimClusIdx, 0)

--- a/modules/running_plots.py
+++ b/modules/running_plots.py
@@ -98,7 +98,7 @@ class RunningEfficiencyFakeRateCallback(tf.keras.callbacks.Callback):
         cc = y_pred[1]
         pred_energy = y_pred[2]
 
-        feat, t_idx, t_energy, t_pos, t_time, t_pid, row_splits = self.td.interpretAllModelInputs(x)
+        feat, t_idx, t_energy, t_pos, t_time, t_pid, t_spectator, t_fully_contained, row_splits = self.td.interpretAllModelInputs(x)
 
         feat_dict = self.td.createFeatureDict(feat)
 


### PR DESCRIPTION
Fix a bug where uncorrected energy was used in feature array. Now use muon-corrected energy everywhere. Also fix use of TrainData_OC instead of TrainData_NanoML, which caused features to be incorrectly ordered by interpretAllModelInputs