### PR TITLE
Energy resolution estimator 

### DIFF
--- a/Train/cheplike_training.py
+++ b/Train/cheplike_training.py
@@ -71,13 +71,15 @@ loss_options={
     'q_min': .1,
     'use_average_cc_pos': 0.1,
     'classification_loss_weight':1e-2,
-    'too_much_beta_scale': 1e-3
+    'too_much_beta_scale': 1e-3,
+    'low_energy_tau': 0.16,
+    'high_energy_tau': 0.84,   
     }
 
 
 dense_activation='relu'
 
-plotfrequency=200
+plotfrequency= 200
 
 learningrate = 5e-5
 nbatch = 500000
@@ -227,7 +229,8 @@ def gravnet_model(Inputs,
     x = GooeyBatchNorm(**batchnorm_options,name='gooey_pre_out')(x)
     x = Concatenate()([c_coords]+[x])
     
-    pred_beta, pred_ccoords, pred_dist, pred_energy_corr, \
+    pred_beta, pred_ccoords, pred_dist,\
+    pred_energy_corr, pred_energy_low_quantile, pred_energy_high_quantile,\
     pred_pos, pred_time, pred_id = create_outputs(x, pre_selection['unproc_features'], 
                                                   n_ccoords=n_cluster_space_coordinates)
     
@@ -242,7 +245,8 @@ def gravnet_model(Inputs,
                                          **loss_options
                                          )(  # oc output and payload
         [pred_beta, pred_ccoords, pred_dist,
-         pred_energy_corr, pred_pos, pred_time, pred_id] +
+         pred_energy_corr,pred_energy_low_quantile,pred_energy_high_quantile,
+         pred_pos, pred_time, pred_id] +
         [energy]+
         # truth information
         [pre_selection['t_idx'] ,
@@ -266,6 +270,8 @@ def gravnet_model(Inputs,
         pred_ccoords,
         pred_beta,
         pred_energy_corr,
+        pred_energy_low_quantile,
+        pred_energy_high_quantile,
         pred_pos,
         pred_time,
         pred_id,
@@ -304,8 +310,9 @@ samplepath=train.val_data.getSamplePath(train.val_data.samples[0])
 # publishpath = 'jkiesele@lxplus.cern.ch:/eos/home-j/jkiesele/www/files/HGCalML_trainings/'+os.path.basename(os.path.normpath(train.outputDir))
 
 
-publishpath = "jkiesele@lxplus.cern.ch:~/Cernbox/www/files/temp/Jan2022/"
-publishpath += [d  for d in train.outputDir.split('/') if len(d)][-1] 
+#publishpath = "jkiesele@lxplus.cern.ch:~/Cernbox/www/files/temp/Jan2022/"
+#publishpath += [d  for d in train.outputDir.split('/') if len(d)][-1] 
+publishpath = [d  for d in train.outputDir.split('/') if len(d)][-1] 
 
 cb = []
 

--- a/Train/cheplike_training.py
+++ b/Train/cheplike_training.py
@@ -71,9 +71,7 @@ loss_options={
     'q_min': .1,
     'use_average_cc_pos': 0.1,
     'classification_loss_weight':1e-2,
-    'too_much_beta_scale': 1e-3,
-    'low_energy_tau': 0.16,
-    'high_energy_tau': 0.84,   
+    'too_much_beta_scale': 1e-3 
     }
 
 

--- a/Train/cheplike_training.py
+++ b/Train/cheplike_training.py
@@ -79,7 +79,7 @@ loss_options={
 
 dense_activation='relu'
 
-plotfrequency= 200
+plotfrequency=200
 
 learningrate = 5e-5
 nbatch = 500000

--- a/Train/cheplike_training.py
+++ b/Train/cheplike_training.py
@@ -310,9 +310,8 @@ samplepath=train.val_data.getSamplePath(train.val_data.samples[0])
 # publishpath = 'jkiesele@lxplus.cern.ch:/eos/home-j/jkiesele/www/files/HGCalML_trainings/'+os.path.basename(os.path.normpath(train.outputDir))
 
 
-#publishpath = "jkiesele@lxplus.cern.ch:~/Cernbox/www/files/temp/Jan2022/"
-#publishpath += [d  for d in train.outputDir.split('/') if len(d)][-1] 
-publishpath = [d  for d in train.outputDir.split('/') if len(d)][-1] 
+publishpath = "jkiesele@lxplus.cern.ch:~/Cernbox/www/files/temp/Jan2022/"
+publishpath += [d  for d in train.outputDir.split('/') if len(d)][-1] 
 
 cb = []
 

--- a/Train/multigrav_training.py
+++ b/Train/multigrav_training.py
@@ -71,9 +71,7 @@ batchnorm_options={
 loss_options={
     'q_min': 2.5,
     'alt_energy_weight': False,
-    'use_average_cc_pos': 0.99,
-    'low_energy_tau': 0.16,
-    'high_energy_tau': 0.84,  
+    'use_average_cc_pos': 0.99  
     }
 
 

--- a/Train/multigrav_training.py
+++ b/Train/multigrav_training.py
@@ -71,7 +71,9 @@ batchnorm_options={
 loss_options={
     'q_min': 2.5,
     'alt_energy_weight': False,
-    'use_average_cc_pos': 0.99
+    'use_average_cc_pos': 0.99,
+    'low_energy_tau': 0.16,
+    'high_energy_tau': 0.84,  
     }
 
 
@@ -201,7 +203,8 @@ def gravnet_model(Inputs,
     x = GooeyBatchNorm(**batchnorm_options)(x)
     x = Concatenate()([c_coords]+[x])
     
-    pred_beta, pred_ccoords, pred_dist, pred_energy_corr, \
+    pred_beta, pred_ccoords, pred_dist,\
+    pred_energy_corr, pred_energy_low_quantile, pred_energy_high_quantile,\
     pred_pos, pred_time, pred_id = create_outputs(x, pre_selection['unproc_features'], 
                                                   n_ccoords=n_cluster_space_coordinates)
     
@@ -220,7 +223,8 @@ def gravnet_model(Inputs,
                                          **loss_options
                                          )(  # oc output and payload
         [pred_beta, pred_ccoords, pred_dist,
-         pred_energy_corr, pred_pos, pred_time, pred_id] +
+         pred_energy_corr,pred_energy_low_quantile,pred_energy_high_quantile,
+         pred_pos, pred_time, pred_id] +
         [energy]+
         # truth information
          [pre_selection['t_idx'] ,
@@ -244,6 +248,8 @@ def gravnet_model(Inputs,
         pred_ccoords,
         pred_beta,
         pred_energy_corr,
+        pred_energy_low_quantile,
+        pred_energy_high_quantile,
         pred_pos,
         pred_time,
         pred_id,

--- a/Train/pca_training.py
+++ b/Train/pca_training.py
@@ -57,12 +57,6 @@ make this about coordinate shifts
 
 '''
 
-#loss options:
-loss_options={
-    'low_energy_tau': 0.16,
-    'high_energy_tau': 0.84,  
-    }
-
 
 def gravnet_model(Inputs,
                   td,
@@ -239,8 +233,7 @@ def gravnet_model(Inputs,
                                          # phase_transition=1,
                                          #huber_energy_scale=0.1,
                                          use_average_cc_pos=0.2,  # smoothen it out a bit
-                                         name="FullOCLoss",
-                                         **loss_options
+                                         name="FullOCLoss"
                                          )(  # oc output and payload
         [pred_beta, pred_ccoords, pred_dist,
          pred_energy_corr,pred_energy_low_quantile,pred_energy_high_quantile,

--- a/Train/pca_training.py
+++ b/Train/pca_training.py
@@ -57,7 +57,11 @@ make this about coordinate shifts
 
 '''
 
-
+#loss options:
+loss_options={
+    'low_energy_tau': 0.16,
+    'high_energy_tau': 0.84,  
+    }
 
 
 def gravnet_model(Inputs,
@@ -212,7 +216,8 @@ def gravnet_model(Inputs,
                        name='gooey_pre_out')(x)
     x = Concatenate()([c_coords]+[x])
     
-    pred_beta, pred_ccoords, pred_dist, pred_energy_corr, \
+    pred_beta, pred_ccoords, pred_dist,\
+    pred_energy_corr, pred_energy_low_quantile, pred_energy_high_quantile,\
     pred_pos, pred_time, pred_id = create_outputs(x, pre_selection['unproc_features'], 
                                                   n_ccoords=n_cluster_space_coordinates)
     
@@ -234,10 +239,12 @@ def gravnet_model(Inputs,
                                          # phase_transition=1,
                                          #huber_energy_scale=0.1,
                                          use_average_cc_pos=0.2,  # smoothen it out a bit
-                                         name="FullOCLoss"
+                                         name="FullOCLoss",
+                                         **loss_options
                                          )(  # oc output and payload
         [pred_beta, pred_ccoords, pred_dist,
-         pred_energy_corr, pred_pos, pred_time, pred_id] +
+         pred_energy_corr,pred_energy_low_quantile,pred_energy_high_quantile,
+         pred_pos, pred_time, pred_id] +
         [energy]+
         # truth information
          [pre_selection['t_idx'] ,
@@ -261,6 +268,8 @@ def gravnet_model(Inputs,
         pred_ccoords,
         pred_beta,
         pred_energy_corr,
+        pred_energy_low_quantile,
+        pred_energy_high_quantile,
         pred_pos,
         pred_time,
         pred_id,

--- a/Train/trackml_alpha_training.py
+++ b/Train/trackml_alpha_training.py
@@ -47,12 +47,6 @@ import sql_credentials
 from datetime import datetime
 
 
-#loss options:
-loss_options={
-    'low_energy_tau': 0.16,
-    'high_energy_tau': 0.84,  
-    }
-
 
 td=TrainData_TrackML()
 '''
@@ -245,8 +239,7 @@ def gravnet_model(Inputs,
                                          payload_beta_gradient_damping_strength=0.,
                                          kalpha_damping_strength=0.,#1.,
                                          use_local_distances=True,
-                                         name="FullOCLoss",
-                                         **loss_options                                         
+                                         name="FullOCLoss"
                                          )([pred_beta, pred_ccoords,
                                             pred_dist,
                                             pred_energy,

--- a/Train/trackml_alpha_training.py
+++ b/Train/trackml_alpha_training.py
@@ -47,6 +47,13 @@ import sql_credentials
 from datetime import datetime
 
 
+#loss options:
+loss_options={
+    'low_energy_tau': 0.16,
+    'high_energy_tau': 0.84,  
+    }
+
+
 td=TrainData_TrackML()
 '''
 
@@ -215,7 +222,9 @@ def gravnet_model(Inputs,
     x = Dense(64, activation='elu')(x)
     x = Dense(64, activation='elu')(x)
 
-    pred_beta, pred_ccoords, pred_dist, pred_energy, pred_pos, pred_time, pred_id = create_outputs(x,feat,add_distance_scale=True)
+    pred_beta, pred_ccoords, pred_dist,\
+    pred_energy_corr, pred_energy_low_quantile, pred_energy_high_quantile,\
+    pred_pos, pred_time, pred_id = create_outputs(x,feat,add_distance_scale=True)
 
     #loss
     pred_beta = LLFullObjectCondensation(print_loss=True,
@@ -236,10 +245,12 @@ def gravnet_model(Inputs,
                                          payload_beta_gradient_damping_strength=0.,
                                          kalpha_damping_strength=0.,#1.,
                                          use_local_distances=True,
-                                         name="FullOCLoss"
+                                         name="FullOCLoss",
+                                         **loss_options                                         
                                          )([pred_beta, pred_ccoords,
                                             pred_dist,
                                             pred_energy,
+                                            pred_energy_low_quantile,pred_energy_high_quantile,
                                             pred_pos, pred_time, pred_id,
                                             orig_t_idx, orig_t_energy, orig_t_pos, orig_t_time, orig_t_pid,
                                             row_splits])

--- a/modules/LossLayers.py
+++ b/modules/LossLayers.py
@@ -667,8 +667,6 @@ class LLFullObjectCondensation(LossLayerBase):
                  super_repulsion=False,
                  use_local_distances=True,
                  energy_weighted_qmin=False,
-                 low_energy_tau=0.16,
-                 high_energy_tau=0.84, 
                  super_attraction=False,
                  div_repulsion=False,
                  dynamic_payload_scaling_onset=-0.005,
@@ -766,8 +764,6 @@ class LLFullObjectCondensation(LossLayerBase):
         self.super_repulsion=super_repulsion
         self.use_local_distances = use_local_distances
         self.energy_weighted_qmin=energy_weighted_qmin
-        self.low_energy_tau=low_energy_tau
-        self.high_energy_tau=high_energy_tau
         self.super_attraction = super_attraction
         self.div_repulsion=div_repulsion
         self.dynamic_payload_scaling_onset = dynamic_payload_scaling_onset
@@ -822,7 +818,9 @@ class LLFullObjectCondensation(LossLayerBase):
         resolution =(1-pred_energy/corrtruth) 
         l_low =  resolution - pred_energy_low_quantile
         l_high = resolution - pred_energy_high_quantile
-        euncloss = quantile(l_low,self.low_energy_tau) + quantile(l_high,self.high_energy_tau) 
+        low_energy_tau = 0.16
+        high_energy_tau = 0.84
+        euncloss = quantile(l_low,low_energy_tau) + quantile(l_high,high_energy_tau) 
 
         return eloss, euncloss
     
@@ -1084,8 +1082,6 @@ class LLFullObjectCondensation(LossLayerBase):
             'super_repulsion': self.super_repulsion,
             'use_local_distances': self.use_local_distances,
             'energy_weighted_qmin': self.energy_weighted_qmin,
-            'low_energy_tau': self.low_energy_tau,
-            'high_energy_tau': self.high_energy_tau,
             'super_attraction':self.super_attraction,
             'div_repulsion' : self.div_repulsion,
             'dynamic_payload_scaling_onset': self.dynamic_payload_scaling_onset

--- a/modules/OCHits2Showers.py
+++ b/modules/OCHits2Showers.py
@@ -132,11 +132,15 @@ class OCHits2Showers():
         processed_pred_dict = dict()
         processed_pred_dict['pred_sid'] = pred_sid
         processed_pred_dict['pred_energy'] = np.zeros_like(processed_pred_dict['pred_sid'], np.float)
+        processed_pred_dict['pred_energy_unc'] = np.zeros_like(processed_pred_dict['pred_sid'], np.float)
 
         for idx in pred_shower_alpha_idx:
             filter = (processed_pred_dict['pred_sid']==pred_sid[idx])[:,0]
             processed_pred_dict['pred_energy'][filter] \
                 = np.sum(pred_dict['pred_energy_corr_factor'][filter] * features_dict['recHitEnergy'][filter])
+        processed_pred_dict['pred_energy_unc'] \
+            = 0.5*(pred_dict['pred_energy_high_quantile']-pred_dict['pred_energy_low_quantile'])
+        processed_pred_dict['pred_energy_unc'] = np.where(processed_pred_dict['pred_energy_unc']>=0,processed_pred_dict['pred_energy_unc'],-1.)
 
         processed_pred_dict.update(pred_dict)
         processed_pred_dict.pop('pred_beta')

--- a/modules/hplots/general_graph_plot.py
+++ b/modules/hplots/general_graph_plot.py
@@ -1,0 +1,87 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+class GeneralGraphPlot():
+    def __init__(self, x_label='Values', y_label='Frequency', title='', histogram_log=False):
+        self.models_data = list()
+
+        self.x_label = x_label
+        self.y_label = y_label
+        self.title = title
+        self.histogram_log=histogram_log
+
+
+    def _compute(self, x_values,y_values):
+        processed_data = dict()
+        processed_data['x_values'] = x_values
+        processed_data['y_values'] = y_values
+        return processed_data
+
+    def add_raw_values(self, x_values,y_values, tags={}):
+        if type(x_values) is not np.ndarray or type(y_values) is not np.ndarray:
+            raise ValueError("x and y values has to be numpy array")
+
+        data = self._compute(x_values,y_values)
+        data['tags'] = tags
+        self.models_data.append(data)
+
+    def add_processed_data(self, processed_data):
+        self.models_data.append(processed_data)
+
+    def draw(self, name_tag_formatter=None):
+        """
+
+        :param name_tag_formatter: a function to which tags dict is given and it returns the name
+        :return:
+        """
+        fig, ax1 = plt.subplots(1, 1, figsize=(6, 6))
+
+        max_of_hist_values = 0
+        for model_data in self.models_data:
+            x_values = model_data['x_values']
+            y_values = model_data['y_values']
+
+            tags = model_data['tags']
+
+            if name_tag_formatter is None:
+                name_of_plot = ''
+            else:
+                name_of_plot = name_tag_formatter(tags)
+
+            print(name_of_plot)
+
+            ax1.plot(x_values, y_values, color='black',linestyle='None', alpha=1,marker='o')
+
+            if self.histogram_log:
+                ax1.set_yscale('log')
+            ax1.set_title(self.title, fontsize=14)
+
+            ax1.set_xlabel(self.x_label, fontsize=14)
+            ax1.set_ylabel(self.y_label, fontsize=14)
+            #ax1.legend(loc='center right')
+            plt.subplots_adjust(left=0.15)
+
+        # ax1.set_ylim(0, 1.04)
+        # ax2.set_ylim(0, max_of_hist_values * 1.3)
+
+    @classmethod
+    def draw_static(cls, x_values, y_values):
+        plotter = GeneralGraphPlot()
+        plotter.add_raw_values(x_values, y_values, tags=None)
+        plotter.draw()
+
+    def write_to_database(self, database_manager, table_name):
+        pass
+
+
+    def get_tags(self):
+        return [x['tags'] for x in self.models_data]
+
+    def read_from_database(self, database_reading_manager, table_name, experiment_name=None, condition=None):
+        pass
+
+
+
+
+

--- a/modules/hplots/hgcal_analysis_plotter.py
+++ b/modules/hplots/hgcal_analysis_plotter.py
@@ -153,10 +153,8 @@ class HGCalAnalysisPlotter:
         true_resolution =  (self.showers_dataframe['truthHitAssignedEnergies'][filter].to_numpy()\
                             -self.showers_dataframe['pred_energy'][filter].to_numpy())\
                             / self.showers_dataframe['truthHitAssignedEnergies'][filter].to_numpy()
-        #print(true_resolution,resolution_estimator)
-        #print(true_resolution.mean(),resolution_estimator.mean())
-        #res_estim_values, res_true_quantiles = utils.profile(true_resolution,resolution_estimator,bins=30,range=[0,0.3],moments=False,average=False,quantiles=np.array(self.quantiles_res_plot)) 
-        #res_true_values =  0.5*(res_true_quantiles[1]-res_true_quantiles[0])
+        res_estim_values, res_true_quantiles = utils.profile(true_resolution,resolution_estimator,bins=30,range=[0,0.3],moments=False,average=True,quantiles=np.array(self.quantiles_res_plot)) 
+        res_true_values =  0.5*(res_true_quantiles[1]-res_true_quantiles[0])
 
         #resolution estimator plot
         plot = GeneralHistogramPlot(bins=self.energy_res_estimator_bins,x_label='Energy Resolution Estimator', y_label='Counts', title='', histogram_log=False)
@@ -169,9 +167,9 @@ class HGCalAnalysisPlotter:
         self.pdf_resolution_estimator.savefig(plot.draw())
 
         #correlation plot between estimator and real resolution
-        #plot = GeneralGraphPlot(x_label='Average Energy Resolution Estimator', y_label=r'Energy Resolution $\frac{E_{true}-E_{pred}}{E_{true}}$', title='', histogram_log=False)
-        #plot.add_raw_values(res_estim_values,res_true_values)
-        #self.pdf_resolution_estimator.savefig(plot.draw())
+        plot = GeneralGraphPlot(x_label='Average Energy Resolution Estimator', y_label=r'Energy Resolution $\frac{E_{true}-E_{pred}}{E_{true}}$', title='', histogram_log=False)
+        plot.add_raw_values(res_estim_values,res_true_values)
+        self.pdf_resolution_estimator.savefig(plot.draw())
 
 
     def _make_response_plots(self):

--- a/modules/hplots/hgcal_analysis_plotter.py
+++ b/modules/hplots/hgcal_analysis_plotter.py
@@ -7,6 +7,9 @@ from matplotlib.backends.backend_pdf import PdfPages
 
 from hplots.general_2d_plot_extensions_2 import EfficiencyFakeRatePlot, ResponsePlot, ResolutionPlot
 from hplots.general_hist_extensions import ResponseHisto, Multi4HistEnergy
+from hplots.general_hist_plot import GeneralHistogramPlot
+from hplots.general_graph_plot import GeneralGraphPlot
+import hplots.utils as utils
 
 def eta_transform(eta):
     eta = np.abs(eta)
@@ -19,6 +22,9 @@ class HGCalAnalysisPlotter:
         self.local_shower_fraction_bins = np.array([0, 0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0])
         self.eta_bins = np.array([1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2.0,2.25,2.5,2.75,3,3.1])
         self.pt_bins = np.array([0, 1., 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,16,18, 20, 25, 30, 40, 50, 60, 70, 80])
+        self.energy_res_bins = np.linspace(-1,1,50)
+        self.energy_res_estimator_bins = np.linspace(0,0.3,50)
+        self.quantiles_res_plot = [0.25,0.75]
 
     def set_energy_bins(self, energy_bins):
         self.energy_bins = energy_bins
@@ -32,6 +38,8 @@ class HGCalAnalysisPlotter:
     def set_pt_bins(self, pt_bins):
         self.pt_bins = pt_bins
 
+    def set_quantiles_res_plot(self, quantiles):
+        self.quantiles_res_plot = quantiles
 
     def _make_pdfs(self, ):
         if os.path.exists(self.pdf_path):
@@ -48,6 +56,7 @@ class HGCalAnalysisPlotter:
         self.pdf_fake_rate = PdfPages(os.path.join(self.pdf_path,'fake_rate.pdf'))
         self.pdf_others = PdfPages(os.path.join(self.pdf_path,'others.pdf'))
         self.pdf_resolution = PdfPages(os.path.join(self.pdf_path,'resolution.pdf'))
+        self.pdf_resolution_estimator = PdfPages(os.path.join(self.pdf_path,'resolution_estimator.pdf'))
         self.pdf_response_histos = PdfPages(os.path.join(self.pdf_path,'response_histos.pdf'))
 
     def _close_pdfs(self):
@@ -57,6 +66,7 @@ class HGCalAnalysisPlotter:
         self.pdf_others.close()
         # self.pdf_pid.close()
         self.pdf_resolution.close()
+        self.pdf_resolution_estimator.close()
         self.pdf_response_histos.close()
         plt.close('all')
 
@@ -134,6 +144,35 @@ class HGCalAnalysisPlotter:
         plot.add_raw_values(self.showers_dataframe['truth_e_other'][filter].to_numpy(),
                             response)
         self.pdf_resolution.savefig(plot.draw())
+
+    def _make_resolution_estimator_plots(self):
+        filter_has_truth = self.showers_dataframe['truthHitAssignementIdx'].notnull()
+        filter_has_pred = self.showers_dataframe['pred_sid'].notnull()
+        filter = np.logical_and(filter_has_truth, filter_has_pred)
+        resolution_estimator = self.showers_dataframe['pred_energy_unc'][filter].to_numpy()
+        true_resolution =  (self.showers_dataframe['truthHitAssignedEnergies'][filter].to_numpy()\
+                            -self.showers_dataframe['pred_energy'][filter].to_numpy())\
+                            / self.showers_dataframe['truthHitAssignedEnergies'][filter].to_numpy()
+        #print(true_resolution,resolution_estimator)
+        #print(true_resolution.mean(),resolution_estimator.mean())
+        #res_estim_values, res_true_quantiles = utils.profile(true_resolution,resolution_estimator,bins=30,range=[0,0.3],moments=False,average=False,quantiles=np.array(self.quantiles_res_plot)) 
+        #res_true_values =  0.5*(res_true_quantiles[1]-res_true_quantiles[0])
+
+        #resolution estimator plot
+        plot = GeneralHistogramPlot(bins=self.energy_res_estimator_bins,x_label='Energy Resolution Estimator', y_label='Counts', title='', histogram_log=False)
+        plot.add_raw_values(resolution_estimator)
+        self.pdf_resolution_estimator.savefig(plot.draw())
+
+        #true resolution plot
+        plot = GeneralHistogramPlot(bins=self.energy_res_bins,x_label=r'Energy Resolution $\frac{E_{true}-E_{pred}}{E_{true}}$', y_label='Counts', title='', histogram_log=False)
+        plot.add_raw_values(true_resolution)
+        self.pdf_resolution_estimator.savefig(plot.draw())
+
+        #correlation plot between estimator and real resolution
+        #plot = GeneralGraphPlot(x_label='Average Energy Resolution Estimator', y_label=r'Energy Resolution $\frac{E_{true}-E_{pred}}{E_{true}}$', title='', histogram_log=False)
+        #plot.add_raw_values(res_estim_values,res_true_values)
+        #self.pdf_resolution_estimator.savefig(plot.draw())
+
 
     def _make_response_plots(self):
         filter_has_truth = self.showers_dataframe['truthHitAssignementIdx'].notnull()
@@ -262,6 +301,7 @@ class HGCalAnalysisPlotter:
         self._make_fake_rate_plots()
         self._make_response_plots()
         self._make_resolution_plots()
+        self._make_resolution_estimator_plots()
         self._make_response_histograms()
 
         self._close_pdfs()

--- a/modules/hplots/utils.py
+++ b/modules/hplots/utils.py
@@ -1,0 +1,43 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+def profile(target,xvar,bins=10,range=None,uniform=False,moments=True,
+            quantiles=np.array([0.25,0.75]),average=False):
+
+    if range is None:
+        if type(bins) is not int:
+            xmin, xmax = bins.min(), bins.max()
+        else:
+            xmin, xmax = xvar.min(),xvar.max()
+    else:
+        xmin, xmax = range
+    mask = ( xvar >= xmin ) & ( xvar <= xmax )
+    xvar = xvar[mask]
+    target = target[mask]
+    if type(bins) == int:
+        if uniform:
+            bins = np.linspace(xmin,xmax,num=bins+1)
+        else:
+            bins = np.percentile( xvar, np.linspace(0,100.,num=bins+1) )
+            bins[0] = xmin
+            bins[-1] = xmax
+    ibins = np.digitize(xvar,bins)-1
+    categories = np.eye(np.max(ibins)+1)[ibins]
+
+    ret = [bins]
+    print(ibins,categories,ret)
+
+    mxvar=xvar.reshape(-1,1) * categories
+    if average==True : ret = [ np.average(mxvar,weights=categories,axis=0) ]
+    if moments:
+        mtarget = target.reshape(-1,1) * categories
+        weights = categories
+        mean = np.average(mtarget,weights=categories,axis=0)
+        mean2 = np.average(mtarget**2,weights=categories,axis=0)
+        ret.extend( [mean, np.sqrt( mean2 - mean**2)] )
+    if quantiles is not None:
+        values = []
+        for ibin in np.arange(categories.shape[1],dtype=int):
+            values.append( np.percentile(target[categories[:,ibin].astype(np.bool)],quantiles*100.,axis=0).reshape(-1,1) )
+        ret.append( np.concatenate(values,axis=-1) )
+    return tuple(ret)

--- a/modules/hplots/utils.py
+++ b/modules/hplots/utils.py
@@ -25,10 +25,12 @@ def profile(target,xvar,bins=10,range=None,uniform=False,moments=True,
     categories = np.eye(np.max(ibins)+1)[ibins]
 
     ret = [bins]
-    print(ibins,categories,ret)
-
     mxvar=xvar.reshape(-1,1) * categories
-    if average==True : ret = [ np.average(mxvar,weights=categories,axis=0) ]
+    if average==True :
+        if (sum(categories)!=0).all(): 
+            ret = [ np.average(mxvar,weights=categories,axis=0) ]
+        else:
+            ret = [bins[:-1]]
     if moments:
         mtarget = target.reshape(-1,1) * categories
         weights = categories
@@ -38,6 +40,10 @@ def profile(target,xvar,bins=10,range=None,uniform=False,moments=True,
     if quantiles is not None:
         values = []
         for ibin in np.arange(categories.shape[1],dtype=int):
-            values.append( np.percentile(target[categories[:,ibin].astype(np.bool)],quantiles*100.,axis=0).reshape(-1,1) )
+            target_in_bin = target[categories[:,ibin].astype(np.bool)]
+            if len(target_in_bin)>0:
+                values.append( np.percentile(target_in_bin,quantiles*100.,axis=0).reshape(-1,1) )
+            else:
+                values.append(np.zeros_like(quantiles).reshape(-1,1))
         ret.append( np.concatenate(values,axis=-1) )
     return tuple(ret)


### PR DESCRIPTION
Main update : 
 - Energy resolution estimator is implemented as half differences of predicted quantiles (customisable by passing the values of quantiles to the LLFullObjectCondensation : low_energy_tau=0.16, high_energy_tau=0.84)
 - Added general_graph_plot class, so we can also make simple graph plots
 - Added plots of energy resolution, resolution estimator and their correlation
 
Implementation :
 - All train scripts are modified to work with the updates. The main difference is that function create_outputs returns also energy_quantiles, which have to be passed to LLFullObjectCondensation, and re_integrate_to_full_hits
 - The weight to the energy resolution estimator is set to energy_weight/2. (half because two quantile losses contribute to the resolution estimator loss)
 - Energy_unc metric is included in metrics.html which is updated during the traninig
 - Plots of energy resolution, resolution estimator and their correlation are implemented in HGCalAnalysisPlotter and are saved in 'resolution_estimator.pdf'. They are also plotted in RunningFullValidation callback.